### PR TITLE
[9.x] Add generic trial scopes for Cashier (Stripe)

### DIFF
--- a/billing.md
+++ b/billing.md
@@ -905,6 +905,14 @@ A complete list of available scopes is available below:
     Subscription::query()->onTrial();
     Subscription::query()->pastDue();
     Subscription::query()->recurring();
+    
+<a name="generic-trial-scope"></a>
+#### Generic Trial Scopes
+
+Just like subscription scopes, you can scope your billable model based on the state of their generic trial:
+    
+    User::query()->onGenericTrial();
+    User::query()->hasExpiredGenericTrial();
 
 <a name="changing-prices"></a>
 ### Changing Prices


### PR DESCRIPTION
This adds documentation for the scopes added in https://github.com/laravel/cashier-stripe/pull/1436